### PR TITLE
Update to LTS-8.17.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-7.5
+resolver: lts-8.17
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
The motivation for this change is that purify doesn't work behind a proxy. That's because http-client-tls doesn't respect `http_proxy` and `https_proxy` environment variables until v0.3.4.

https://www.stackage.org/lts-8.17/package/http-client-tls-0.3.5#changes

Updating to http-client-tls >= 0.3.4 fixes the problem. The simplest way to do that is just update to >= LTS-8.3. (In this commit I've updated to the latest LTS available though.)